### PR TITLE
[bugfix] fix header byte related bug

### DIFF
--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -89,7 +89,7 @@ func parseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 	// If the parent chain sequencer inbox smart contract authenticated this batch,
 	// an unknown header byte must mean that this node is out of date,
 	// because the smart contract understands the header byte and this node doesn't.
-	if len(payload) > 0 && IsL1AuthenticatedMessageHeaderByte(payload[0]) && !IsKnownHeaderByte(payload[0]) {
+	if len(payload) > 0 && IsL1AuthenticatedMessageHeaderByte(payload[0]) && !IsKnownHeaderByte(payload[0]) && !eigenda.IsEigenDAMessageHeaderByte(payload[0]) {
 		return nil, fmt.Errorf("%w: batch has unsupported authenticated header byte 0x%02x", arbosState.ErrFatalNodeOutOfDate, payload[0])
 	}
 


### PR DESCRIPTION
Add fix to inbox to consider the eigenda message header flag a valid flag

Batch being written to EigenDA:
![Screenshot 2024-04-19 at 12 12 18 PM](https://github.com/Layr-Labs/nitro/assets/84330705/8efbacdb-469a-4a5e-bb8b-57fa637da8b6)

Batch Confirmed and Preimage Recorded:
![Screenshot 2024-04-19 at 12 13 31 PM](https://github.com/Layr-Labs/nitro/assets/84330705/55d1d557-ea99-4acf-9dd5-50de16f9f9fc)