### PR TITLE
feat(arbitrator): EigenDA PreImage Targeting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,7 @@
 	url = https://github.com/google/brotli.git
 [submodule "contracts"]
 	path = contracts
-	url = https://github.com/OffchainLabs/nitro-contracts.git
-	branch = develop
+	url = https://github.com/Layr-Labs/nitro-contracts.git
 [submodule "arbitrator/wasm-testsuite/testsuite"]
 	path = arbitrator/wasm-testsuite/testsuite
 	url = https://github.com/WebAssembly/testsuite.git

--- a/arbitrator/arbutil/src/types.rs
+++ b/arbitrator/arbutil/src/types.rs
@@ -13,4 +13,5 @@ pub enum PreimageType {
     Keccak256,
     Sha2_256,
     EthVersionedHash,
+    EigenDAHash,
 }

--- a/arbitrator/prover/src/host.rs
+++ b/arbitrator/prover/src/host.rs
@@ -52,6 +52,7 @@ pub enum Hostio {
     WavmReadKeccakPreimage,
     WavmReadSha256Preimage,
     WavmReadEthVersionedHashPreimage,
+    WavmReadEigenDAHashPreimage,
     WavmReadInboxMessage,
     WavmReadDelayedInboxMessage,
     WavmHaltAndSetFinished,
@@ -76,6 +77,7 @@ impl FromStr for Hostio {
             ("env", "wavm_read_keccak_256_preimage") => WavmReadKeccakPreimage,
             ("env", "wavm_read_sha2_256_preimage") => WavmReadSha256Preimage,
             ("env", "wavm_read_eth_versioned_hash_preimage") => WavmReadEthVersionedHashPreimage,
+            ("env", "wavm_read_eigen_da_hash_preimage") => WavmReadEigenDAHashPreimage,
             ("env", "wavm_read_inbox_message") => WavmReadInboxMessage,
             ("env", "wavm_read_delayed_inbox_message") => WavmReadDelayedInboxMessage,
             ("env", "wavm_halt_and_set_finished") => WavmHaltAndSetFinished,
@@ -114,6 +116,7 @@ impl Hostio {
             WavmReadKeccakPreimage           => func!([I32, I32], [I32]),
             WavmReadSha256Preimage           => func!([I32, I32], [I32]),
             WavmReadEthVersionedHashPreimage => func!([I32, I32], [I32]),
+            WavmReadEigenDAHashPreimage      => func!([I32, I32], [I32]),
             WavmReadInboxMessage             => func!([I64, I32, I32], [I32]),
             WavmReadDelayedInboxMessage      => func!([I64, I32, I32], [I32]),
             WavmHaltAndSetFinished           => func!(),
@@ -187,6 +190,11 @@ impl Hostio {
                 opcode!(LocalGet, 0);
                 opcode!(LocalGet, 1);
                 opcode!(ReadPreImage, PreimageType::EthVersionedHash);
+            }
+            WavmReadEigenDAHashPreimage => {
+                opcode!(LocalGet, 0);
+                opcode!(LocalGet, 1);
+                opcode!(ReadPreImage, PreimageType::EigenDAHash);
             }
             WavmReadInboxMessage => {
                 opcode!(LocalGet, 0);

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -2322,6 +2322,11 @@ impl Machine {
                                 prove_kzg_preimage(hash, &preimage, offset, &mut data)
                                     .expect("Failed to generate KZG preimage proof");
                             }
+                            PreimageType::EigenDAHash => {
+                                // TODO - Add eigenDA kzg preimage verification here
+                                println!("Generating proof for EigenDA preimage");
+                                data.extend(preimage);
+                            }
                         }
                     } else if next_inst.opcode == Opcode::ReadInboxMessage {
                         let msg_idx = self

--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -166,6 +166,9 @@ fn main() -> Result<()> {
                 .insert(hash.into(), buf.as_slice().into());
         }
     }
+    // output preimage oracle
+    println!("preimages {:?}", preimages);
+
     let preimage_resolver =
         Arc::new(move |_, ty, hash| preimages.get(&ty).and_then(|m| m.get(&hash)).cloned())
             as PreimageResolver;

--- a/arbitrator/prover/src/main.rs
+++ b/arbitrator/prover/src/main.rs
@@ -166,9 +166,7 @@ fn main() -> Result<()> {
                 .insert(hash.into(), buf.as_slice().into());
         }
     }
-    // output preimage oracle
-    println!("preimages {:?}", preimages);
-
+    
     let preimage_resolver =
         Arc::new(move |_, ty, hash| preimages.get(&ty).and_then(|m| m.get(&hash)).cloned())
             as PreimageResolver;

--- a/arbitrator/prover/src/utils.rs
+++ b/arbitrator/prover/src/utils.rs
@@ -282,12 +282,8 @@ pub fn hash_preimage(preimage: &[u8], ty: PreimageType) -> Result<[u8; 32]> {
             Ok(commitment_hash)
         }
         PreimageType::EigenDAHash => {
-            println!("Generating EigenDA preimage type");
-
-            let hash: [u8; 32] = Sha256::digest(preimage).into();
-            println!("Generated preimage hash {:?}", hash);
-            // TODO: Add support for generati ng hashes for an eigenDA kzg commitment
-            Ok(hash)
+            // TODO: Add support for generating hashes for an eigenDA kzg commitment
+            Ok(Sha256::digest(preimage).into())
         }
     }
 }

--- a/arbitrator/prover/src/utils.rs
+++ b/arbitrator/prover/src/utils.rs
@@ -281,5 +281,13 @@ pub fn hash_preimage(preimage: &[u8], ty: PreimageType) -> Result<[u8; 32]> {
             commitment_hash[0] = 1;
             Ok(commitment_hash)
         }
+        PreimageType::EigenDAHash => {
+            println!("Generating EigenDA preimage type");
+
+            let hash: [u8; 32] = Sha256::digest(preimage).into();
+            println!("Generated preimage hash {:?}", hash);
+            // TODO: Add support for generati ng hashes for an eigenDA kzg commitment
+            Ok(hash)
+        }
     }
 }

--- a/arbitrator/prover/test-cases/go/main.go
+++ b/arbitrator/prover/test-cases/go/main.go
@@ -140,5 +140,10 @@ func main() {
 		}
 	}
 
+	_, err = wavmio.ResolveTypedPreimage(arbutil.EigenDaPreimageType, common.HexToHash("b071b0cf4fc3288ada3977d7b5b0ff621d238f0f8bebb1def70cf7cf0aa59f41"))
+	if err != nil {
+		panic(fmt.Sprintf("failed to resolve eigenda preimage: %v", err))
+	}
+
 	println("verified preimage resolution!\n")
 }

--- a/arbitrator/prover/test-cases/rust/src/bin/host-io.rs
+++ b/arbitrator/prover/test-cases/rust/src/bin/host-io.rs
@@ -6,6 +6,7 @@ extern "C" {
     pub fn wavm_read_keccak_256_preimage(ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_sha2_256_preimage(ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_eth_versioned_hash_preimage(ptr: *mut u8, offset: usize) -> usize;
+    pub fn wavm_read_eigen_da_hash_preimage(ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_inbox_message(msg_num: u64, ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_delayed_inbox_message(seq_num: u64, ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_halt_and_set_finished();
@@ -102,6 +103,16 @@ fn main() {
             expected_hash[32-scalar_bytes.len()..].copy_from_slice(&scalar_bytes);
             assert_eq!(bytebuffer.0, expected_hash);
         }
+
+        println!("eigenda preimage");
+        let eigen_hash = hex!("b071b0cf4fc3288ada3977d7b5b0ff621d238f0f8bebb1def70cf7cf0aa59f41");
+        bytebuffer = Bytes32(eigen_hash);
+        let expected_len = 32;
+
+        let actual_len = wavm_read_eigen_da_hash_preimage(bytebuffer.0.as_mut_ptr(), 0);
+        assert_eq!(actual_len, expected_len);
+        // Ensure that 0th index is zero padded
+        assert_eq!(bytebuffer.0[..actual_len][0] as u8, 0);
     }
     println!("Done!");
 }

--- a/arbitrator/wasm-libraries/host-io/src/lib.rs
+++ b/arbitrator/wasm-libraries/host-io/src/lib.rs
@@ -10,6 +10,7 @@ extern "C" {
     pub fn wavm_read_keccak_256_preimage(ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_sha2_256_preimage(ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_eth_versioned_hash_preimage(ptr: *mut u8, offset: usize) -> usize;
+    pub fn wavm_read_eigen_da_hash_preimage(ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_inbox_message(msg_num: u64, ptr: *mut u8, offset: usize) -> usize;
     pub fn wavm_read_delayed_inbox_message(seq_num: u64, ptr: *mut u8, offset: usize) -> usize;
 }
@@ -152,6 +153,7 @@ pub unsafe extern "C" fn go__github_com_offchainlabs_nitro_wavmio_resolveTypedPr
         PreimageType::Keccak256 => wavm_read_keccak_256_preimage,
         PreimageType::Sha2_256 => wavm_read_sha2_256_preimage,
         PreimageType::EthVersionedHash => wavm_read_eth_versioned_hash_preimage,
+        PreimageType::EigenDAHash => wavm_read_eigen_da_hash_preimage,
     };
     let read = preimage_reader(our_ptr, offset as usize);
     assert!(read <= 32);

--- a/arbstate/inbox.go
+++ b/arbstate/inbox.go
@@ -89,7 +89,7 @@ func parseSequencerMessage(ctx context.Context, batchNum uint64, batchBlockHash 
 	// If the parent chain sequencer inbox smart contract authenticated this batch,
 	// an unknown header byte must mean that this node is out of date,
 	// because the smart contract understands the header byte and this node doesn't.
-	if len(payload) > 0 && IsL1AuthenticatedMessageHeaderByte(payload[0]) && !IsKnownHeaderByte(payload[0]) {
+	if len(payload) > 0 && IsL1AuthenticatedMessageHeaderByte(payload[0]) && !IsKnownHeaderByte(payload[0]) && !eigenda.IsEigenDAMessageHeaderByte(payload[0]) {
 		return nil, fmt.Errorf("%w: batch has unsupported authenticated header byte 0x%02x", arbosState.ErrFatalNodeOutOfDate, payload[0])
 	}
 

--- a/arbutil/preimage_type.go
+++ b/arbutil/preimage_type.go
@@ -11,4 +11,5 @@ const (
 	Keccak256PreimageType PreimageType = iota
 	Sha2_256PreimageType
 	EthVersionedHashPreimageType
+	EigenDaPreimageType
 )

--- a/das/eigenda/eigenda.go
+++ b/das/eigenda/eigenda.go
@@ -187,10 +187,10 @@ func RecoverPayloadFromEigenDABatch(ctx context.Context,
 	log.Info("Start recovering payload from eigenda: ", "data", hex.EncodeToString(sequencerMsg))
 	var shaPreimages map[common.Hash][]byte
 	if preimages != nil {
-		if preimages[arbutil.Sha2_256PreimageType] == nil {
-			preimages[arbutil.Sha2_256PreimageType] = make(map[common.Hash][]byte)
+		if preimages[arbutil.EigenDaPreimageType] == nil {
+			preimages[arbutil.EigenDaPreimageType] = make(map[common.Hash][]byte)
 		}
-		shaPreimages = preimages[arbutil.Sha2_256PreimageType]
+		shaPreimages = preimages[arbutil.EigenDaPreimageType]
 	}
 	var daRef EigenDARef
 	daRef.BlobIndex = binary.BigEndian.Uint32(sequencerMsg[:4])

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,8 @@ replace github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
-	github.com/Layr-Labs/eigenda v0.6.0
+	github.com/Layr-Labs/eigenda v0.6.1
+	github.com/Layr-Labs/eigenda/api v0.6.1
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/alicebob/miniredis/v2 v2.21.0
 	github.com/andybalholm/brotli v1.0.4
@@ -312,7 +313,6 @@ require (
 )
 
 require (
-	github.com/Layr-Labs/eigenda/api v0.6.0
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/VictoriaMetrics/fastcache v1.12.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,10 @@ github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKz
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
-github.com/Layr-Labs/eigenda v0.6.0 h1:CSoXJX3KboRtq3SJAs1AKdSXOhjUfafX94Kg1KU0dUw=
-github.com/Layr-Labs/eigenda v0.6.0/go.mod h1:XongI0xM6ks66DzxvTpF2yi4x2QH0X2RgEbKl/WFebY=
-github.com/Layr-Labs/eigenda/api v0.6.0 h1:TrmmeklRIqR91C48V9malQEFMHEcfv2iF+2aTA4Hw+s=
-github.com/Layr-Labs/eigenda/api v0.6.0/go.mod h1:kVXqWM13s/1hXyv9QdHweWAbKin9MeOBbS4i8c9rLbU=
+github.com/Layr-Labs/eigenda v0.6.1 h1:uU04t+dsR5oHsbr+A5XIeJdyZIfNW3YvG03dMTKLSK4=
+github.com/Layr-Labs/eigenda v0.6.1/go.mod h1:XongI0xM6ks66DzxvTpF2yi4x2QH0X2RgEbKl/WFebY=
+github.com/Layr-Labs/eigenda/api v0.6.1 h1:TAstOttTmFZQoFlZtgu/rNktNOhx62TwRFMxGOhUx8M=
+github.com/Layr-Labs/eigenda/api v0.6.1/go.mod h1:kVXqWM13s/1hXyv9QdHweWAbKin9MeOBbS4i8c9rLbU=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/scripts/create-test-preimages.py
+++ b/scripts/create-test-preimages.py
@@ -24,6 +24,20 @@ def kzg_test_data():
         data.extend(h)
     return bytes(data)
 
+def eigen_test_data():
+    data = []
+    # generate ten 32 byte words to constitute dummy blob data
+    for i in range(0, 1):
+        bytes_64 = bytearray(hashlib.sha512(bytes(str(i), encoding='utf8')).digest())
+        bytes_32 = bytes_64[0:32]
+
+        # 0 padding for 1st byte of 32 byte word
+        bytes_32[0] = 0
+        data.extend(bytes_32)
+
+    print(bytes(data))
+    return bytes(data)
+
 if len(sys.argv) < 2:
     print("Usage: python3 create-test-preimages.py <filename>")
     sys.exit(1)
@@ -34,6 +48,7 @@ preimages = [
     (0, b'hello world'),
     (1, b'hello world'),
     (2, kzg_test_data()),
+    (3, eigen_test_data())
 ]
 
 write_data_to_file(filename, preimages)

--- a/scripts/create-test-preimages.py
+++ b/scripts/create-test-preimages.py
@@ -26,7 +26,7 @@ def kzg_test_data():
 
 def eigen_test_data():
     data = []
-    # generate ten 32 byte words to constitute dummy blob data
+    # generate a 32 byte blob
     for i in range(0, 1):
         bytes_64 = bytearray(hashlib.sha512(bytes(str(i), encoding='utf8')).digest())
         bytes_32 = bytes_64[0:32]


### PR DESCRIPTION
**Changes**
- Extend `scripts/create-test-preimages.py` to generate a test EigenDA preimage using a dummy blob
- Update go and rust arbitrator test scripts to do resolutions for EigenDA preimage types using dummy blob data generated by test script
- Update `host-io` to support targeting for EigenDA preimage types from go compiled to wasm

**Screenshots**
<img width="849" alt="Screenshot 2024-04-30 at 5 23 09 PM" src="https://github.com/Layr-Labs/nitro/assets/42627790/a07d5d96-5019-4d3e-befa-3c70c75d9e5c">
